### PR TITLE
Pre-register AKS in SRE Agent managedResources and add onboarding note

### DIFF
--- a/docs/LAB-GUIDE.md
+++ b/docs/LAB-GUIDE.md
@@ -147,6 +147,8 @@ sre-agent
 
 Or navigate directly to [sre.azure.com](https://sre.azure.com).
 
+> **First-time onboarding screen:** On first launch you'll see a setup wizard asking you to add context sources (Code, Logs, Azure resources, Incidents). The deployment has already pre-configured Azure resources and logs, so click **"Done and go to agent"** to skip this screen.
+
 ### 3.1 — Healthy Baseline Prompts
 
 Before introducing failures, ask the agent to confirm the cluster is healthy. Try these prompts:

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -215,6 +215,9 @@ module sreAgent 'modules/sre-agent.bicep' = if (deploySreAgent) {
     appInsightsAppId: appInsights.outputs.appId
     appInsightsConnectionString: appInsights.outputs.connectionString
     uniqueSuffix: uniqueSuffix
+    managedResourceIds: [
+      aks.outputs.aksId
+    ]
   }
 }
 

--- a/infra/bicep/modules/sre-agent.bicep
+++ b/infra/bicep/modules/sre-agent.bicep
@@ -28,6 +28,9 @@ param appInsightsConnectionString string
 @description('Unique suffix for resource naming')
 param uniqueSuffix string
 
+@description('Resource IDs to add to SRE Agent knowledge graph (e.g. AKS cluster)')
+param managedResourceIds array = []
+
 // =============================================================================
 // VARIABLES
 // =============================================================================
@@ -87,7 +90,7 @@ resource sreAgent 'Microsoft.App/agents@2025-05-01-preview' = {
   properties: {
     knowledgeGraphConfiguration: {
       identity: managedIdentity.id
-      managedResources: []
+      managedResources: managedResourceIds
     }
     actionConfiguration: {
       accessLevel: accessLevel


### PR DESCRIPTION
- Pass AKS cluster ID to SRE Agent module via managedResourceIds param
- Agent starts building knowledge graph at deploy time instead of empty
- Add note in lab guide to click 'Done and go to agent' on first launch