### PR TITLE
Pre-register AKS in SRE Agent managedResources and add onboarding note

### DIFF
--- a/infra/bicep/modules/sre-agent.bicep
+++ b/infra/bicep/modules/sre-agent.bicep
@@ -66,14 +66,16 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-
 }
 
 // Role assignments for the managed identity on this resource group
-resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for (roleId, index) in roleDefinitions[accessLevel]: {
-  name: guid(resourceGroup().id, managedIdentity.id, roleId)
-  properties: {
-    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleId)
-    principalId: managedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
+resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for (roleId, index) in roleDefinitions[accessLevel]: {
+    name: guid(resourceGroup().id, managedIdentity.id, roleId)
+    properties: {
+      roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleId)
+      principalId: managedIdentity.properties.principalId
+      principalType: 'ServicePrincipal'
+    }
   }
-}]
+]
 
 // SRE Agent
 #disable-next-line BCP081


### PR DESCRIPTION
- Pass AKS cluster ID to SRE Agent module via managedResourceIds param
- Agent starts building knowledge graph at deploy time instead of empty
- Add note in lab guide to click 'Done and go to agent' on first launch