### PR TITLE
Complete Azure Monitor automation profile

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -74,6 +74,7 @@ alias azsub='az account list -o table'
 
 # Demo shortcuts
 alias deploy='pwsh ./scripts/deploy.ps1'
+alias deploy-monitor='pwsh ./scripts/deploy.ps1 -EnableAzureMonitorAutomation'
 alias destroy='pwsh ./scripts/destroy.ps1'
 
 # Break scenarios
@@ -127,6 +128,11 @@ function deploy {
     & pwsh -File "./scripts/deploy.ps1" -Location $Location @args 
 }
 
+function deploy-monitor {
+    param([string]$Location = "eastus2")
+    & pwsh -File "./scripts/deploy.ps1" -Location $Location -EnableAzureMonitorAutomation @args
+}
+
 function destroy {
     param([string]$ResourceGroupName)
     if ($ResourceGroupName) {
@@ -172,6 +178,7 @@ function menu {
 ║  Commands:                                                                   ║
 ║    az login --use-device-code  - Login to Azure                              ║
 ║    deploy                      - Deploy the infrastructure                   ║
+║    deploy-monitor              - Deploy with Azure Monitor automation       ║
 ║    destroy                     - Tear down the infrastructure                ║
 ║    site                        - Show the store front URL                    ║
 ║    sre-agent                   - Show SRE Agent portal URL                   ║

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ To opt into the Azure Monitor automation profile, add
 `-EnableAzureMonitorAutomation`. The core deployment leaves alert rules and the
 default action group disabled.
 
+```powershell
+.\scripts\deploy.ps1 -Location eastus2 -Yes -EnableAzureMonitorAutomation
+```
+
+In the dev container, `deploy-monitor -Yes` runs the same opt-in deployment.
+
 Inspect or explicitly remove the enabled profile with:
 
 ```powershell
@@ -153,6 +159,7 @@ deployment is considered ready.
 | Command | Description |
 |---------|-------------|
 | `.\scripts\deploy.ps1 -Location eastus2` | Deploy all infrastructure to Azure |
+| `deploy-monitor -Yes` | Deploy with the optional Azure Monitor automation profile in the dev container |
 | `.\scripts\deploy.ps1 -WhatIf` | Preview what would be deployed |
 | `.\scripts\configure-sre-agent.ps1 -ResourceGroupName <rg>` | Configure SRE Agent (KB, agents, connectors) |
 | `.\scripts\validate-deployment.ps1 -ResourceGroupName <rg>` | Verify resources and app are healthy |

--- a/docs/SRE-AGENT-SETUP.md
+++ b/docs/SRE-AGENT-SETUP.md
@@ -266,6 +266,20 @@ deployment verifier requires those resources only when the profile is enabled.
 Review-mode remediation and incident response plans remain separate controls;
 incident-filter creation is still subject to the compatibility probe below.
 
+Inspect, pause, resume, or clean up the profile with:
+
+```powershell
+.\scripts\manage-azure-monitor-profile.ps1 -ResourceGroupName "rg-srelab-eastus2"
+.\scripts\manage-azure-monitor-profile.ps1 -ResourceGroupName "rg-srelab-eastus2" -Pause
+.\scripts\manage-azure-monitor-profile.ps1 -ResourceGroupName "rg-srelab-eastus2" -Resume
+.\scripts\manage-azure-monitor-profile.ps1 -ResourceGroupName "rg-srelab-eastus2" -RunNow -TaskName hourly-automation-health
+.\scripts\manage-azure-monitor-profile.ps1 -ResourceGroupName "rg-srelab-eastus2" -Cleanup -ConfirmCleanup
+```
+
+`-RunNow` reports exit code `2` when the current SRE Agent API does not expose
+an immediate scheduled-task endpoint. Incident-driven automation still
+requires a portal-created response plan while issue #3 is blocked.
+
 ### Grafana Dashboard
 
 Managed Grafana is linked to the Azure Monitor Workspace and receives the

--- a/docs/SRE-AGENT-SETUP.md
+++ b/docs/SRE-AGENT-SETUP.md
@@ -261,6 +261,12 @@ profile explicitly when testing alert-driven workflows:
 .\scripts\deploy.ps1 -Location eastus2 -Yes -EnableAzureMonitorAutomation
 ```
 
+In the dev container, use the equivalent menu command:
+
+```powershell
+deploy-monitor -Yes
+```
+
 This deploys four symptom-focused alerts and the `ag-srelab` action group. The
 deployment verifier requires those resources only when the profile is enabled.
 Review-mode remediation and incident response plans remain separate controls;

--- a/docs/SRE-AGENT-SETUP.md
+++ b/docs/SRE-AGENT-SETUP.md
@@ -276,6 +276,8 @@ Inspect, pause, resume, or clean up the profile with:
 .\scripts\manage-azure-monitor-profile.ps1 -ResourceGroupName "rg-srelab-eastus2" -Cleanup -ConfirmCleanup
 ```
 
+Pass `-WorkloadName` when the lab was deployed with a non-default workload name.
+
 `-RunNow` reports exit code `2` when the current SRE Agent API does not expose
 an immediate scheduled-task endpoint. Incident-driven automation still
 requires a portal-created response plan while issue #3 is blocked.

--- a/infra/bicep/modules/alerts.bicep
+++ b/infra/bicep/modules/alerts.bicep
@@ -31,7 +31,7 @@ var alertActions = {
   }
 }
 
-resource podRestartAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource podRestartAlert 'Microsoft.Insights/scheduledQueryRules@2025-01-01-preview' = {
   name: '${namePrefix}-pod-restarts'
   location: location
   tags: tags
@@ -66,7 +66,7 @@ resource podRestartAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
   }
 }
 
-resource http5xxAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource http5xxAlert 'Microsoft.Insights/scheduledQueryRules@2025-01-01-preview' = {
   name: '${namePrefix}-http-5xx'
   location: location
   tags: tags
@@ -101,7 +101,7 @@ resource http5xxAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
   }
 }
 
-resource podFailureAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource podFailureAlert 'Microsoft.Insights/scheduledQueryRules@2025-01-01-preview' = {
   name: '${namePrefix}-pod-failures'
   location: location
   tags: tags
@@ -136,7 +136,7 @@ resource podFailureAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
   }
 }
 
-resource crashLoopOomAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource crashLoopOomAlert 'Microsoft.Insights/scheduledQueryRules@2025-01-01-preview' = {
   name: '${namePrefix}-crashloop-oom'
   location: location
   tags: tags

--- a/scripts/configure-sre-agent.ps1
+++ b/scripts/configure-sre-agent.ps1
@@ -69,6 +69,9 @@ param(
     [switch]$EnableMicrosoftLearnMcp,
 
     [Parameter()]
+    [switch]$EnableAzureMonitorAutomation,
+
+    [Parameter()]
     [switch]$SkipScheduledTasks
 )
 
@@ -600,28 +603,52 @@ if (-not $SkipScheduledTasks) {
 
     $token = Get-SreAgentToken
 
-    $taskBody = @{
-        name       = "daily-health-check"
-        type       = "ScheduledTask"
-        properties = @{
-            cronExpression = "0 8 * * *"
-            agentPrompt    = "Run a comprehensive health check of the AKS cluster in the pets namespace. Check all pod statuses, recent restarts, resource utilization, and error trends. Report any issues found with severity ratings."
-            agentName      = "cluster-health-monitor"
-            enabled        = $true
+    $scheduledTasks = @(
+        @{
+            Name = 'daily-health-check'
+            Cron = '0 8 * * *'
+            Prompt = 'Run a comprehensive health check of the AKS cluster in the pets namespace. Check all pod statuses, recent restarts, resource utilization, and error trends. Report any issues found with severity ratings.'
         }
-    } | ConvertTo-Json -Depth 5 -Compress
-
-    $resp = Invoke-DataplaneApi `
-        -Method PUT `
-        -Path "/api/v2/extendedAgent/scheduledTasks/daily-health-check" `
-        -Body $taskBody `
-        -Token $token
-
-    if ($resp.StatusCode -eq 202 -or $resp.StatusCode -eq 200) {
-        Write-Host "  ✅ Scheduled task 'daily-health-check' created (runs daily at 08:00 UTC)" -ForegroundColor Green
+    )
+    if ($EnableAzureMonitorAutomation) {
+        $scheduledTasks += @(
+            @{
+                Name = 'daily-rbac-cost-network-audit'
+                Cron = '30 8 * * *'
+                Prompt = 'Run a read-only audit of the pets demo resource group. Review RBAC scope, estimated cost signals, network configuration, and public exposure. Report findings without making changes.'
+            }
+            @{
+                Name = 'hourly-automation-health'
+                Cron = '0 * * * *'
+                Prompt = 'Run a read-only health check of the pets namespace and Azure Monitor integration. Report active failures, alert readiness, and telemetry gaps. Do not remediate.'
+            }
+        )
     }
-    else {
-        Add-ConfigurationFailure -Component 'Scheduled task/daily-health-check' -Reason "HTTP $($resp.StatusCode)"
+
+    foreach ($task in $scheduledTasks) {
+        $taskBody = @{
+            name       = $task.Name
+            type       = "ScheduledTask"
+            properties = @{
+                cronExpression = $task.Cron
+                agentPrompt    = $task.Prompt
+                agentName      = "cluster-health-monitor"
+                enabled        = $true
+            }
+        } | ConvertTo-Json -Depth 5 -Compress
+
+        $resp = Invoke-DataplaneApi `
+            -Method PUT `
+            -Path "/api/v2/extendedAgent/scheduledTasks/$($task.Name)" `
+            -Body $taskBody `
+            -Token $token
+
+        if ($resp.StatusCode -eq 202 -or $resp.StatusCode -eq 200) {
+            Write-Host "  ✅ Scheduled task '$($task.Name)' created" -ForegroundColor Green
+        }
+        else {
+            Add-ConfigurationFailure -Component "Scheduled task/$($task.Name)" -Reason "HTTP $($resp.StatusCode)"
+        }
     }
 }
 else {

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -827,7 +827,10 @@ if ($outputs.sreAgentId.value) {
             if (-not (Test-Path $verifyScript)) {
                 throw "SRE Agent verifier not found at $verifyScript"
             }
-            $verifyParams = @{ ResourceGroupName = $resourceGroupName }
+            $verifyParams = @{
+                ResourceGroupName = $resourceGroupName
+                WorkloadName      = $WorkloadName
+            }
             if ($EnableMicrosoftLearnMcp) {
                 $verifyParams.RequireMicrosoftLearnMcp = $true
             }

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -814,6 +814,9 @@ if ($outputs.sreAgentId.value) {
             if ($EnableMicrosoftLearnMcp) {
                 $configureParams.EnableMicrosoftLearnMcp = $true
             }
+            if ($EnableAzureMonitorAutomation) {
+                $configureParams.EnableAzureMonitorAutomation = $true
+            }
             & $configureScript @configureParams
             if ($LASTEXITCODE -ne 0) {
                 throw "SRE Agent configuration returned exit code $LASTEXITCODE"
@@ -825,11 +828,11 @@ if ($outputs.sreAgentId.value) {
                 throw "SRE Agent verifier not found at $verifyScript"
             }
             $verifyParams = @{ ResourceGroupName = $resourceGroupName }
-            if ($EnableAzureMonitorAutomation) {
-                $verifyParams.RequireAzureMonitorAutomation = $true
-            }
             if ($EnableMicrosoftLearnMcp) {
                 $verifyParams.RequireMicrosoftLearnMcp = $true
+            }
+            if ($EnableAzureMonitorAutomation) {
+                $verifyParams.RequireAzureMonitorAutomation = $true
             }
             & $verifyScript @verifyParams
             if ($LASTEXITCODE -ne 0) {

--- a/scripts/manage-azure-monitor-profile.ps1
+++ b/scripts/manage-azure-monitor-profile.ps1
@@ -10,6 +10,18 @@
 
 .PARAMETER ConfirmCleanup
     Required with -Cleanup to perform deletion.
+
+.PARAMETER Pause
+    Disable the profile's scheduled audit tasks.
+
+.PARAMETER Resume
+    Enable the profile's scheduled audit tasks.
+
+.PARAMETER RunNow
+    Request an immediate run of one scheduled audit task when supported.
+
+.PARAMETER TaskName
+    Scheduled task used with -RunNow.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
@@ -21,7 +33,20 @@ param(
     [switch]$Cleanup,
 
     [Parameter()]
-    [switch]$ConfirmCleanup
+    [switch]$ConfirmCleanup,
+
+    [Parameter()]
+    [switch]$Pause,
+
+    [Parameter()]
+    [switch]$Resume,
+
+    [Parameter()]
+    [switch]$RunNow,
+
+    [Parameter()]
+    [ValidateSet('daily-rbac-cost-network-audit', 'hourly-automation-health')]
+    [string]$TaskName = 'hourly-automation-health'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -35,6 +60,52 @@ $profileResources = @(
 
 if ($Cleanup -and -not $ConfirmCleanup) {
     throw 'Cleanup requires both -Cleanup and -ConfirmCleanup.'
+}
+
+if (@($Pause, $Resume, $RunNow, $Cleanup | Where-Object { $_ }).Count -gt 1) {
+    throw 'Choose only one of -Pause, -Resume, -RunNow, or -Cleanup.'
+}
+
+if ($Pause -or $Resume -or $RunNow) {
+    $agent = az resource list --resource-group $ResourceGroupName --resource-type Microsoft.App/agents --query '[0]' -o json 2>$null | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0 -or $null -eq $agent) { throw "No SRE Agent found in $ResourceGroupName." }
+    $detail = az resource show --ids $agent.id --api-version 2025-05-01-preview -o json 2>$null | ConvertFrom-Json
+    $endpoint = $detail.properties.agentEndpoint
+    $token = az account get-access-token --resource https://azuresre.dev --query accessToken -o tsv 2>$null
+    if ([string]::IsNullOrWhiteSpace($endpoint) -or [string]::IsNullOrWhiteSpace($token)) { throw 'Could not resolve SRE Agent endpoint or token.' }
+
+    function Invoke-TaskApi {
+        param([ValidateSet('GET', 'POST', 'PUT')][string]$Method, [string]$Path, [string]$Body)
+        $args = @('-sS', '-w', "`n%{http_code}", '-X', $Method, "$endpoint$Path", '-H', "Authorization: Bearer $token", '-H', 'Content-Type: application/json')
+        if ($Body) { $args += @('--data-raw', $Body) }
+        $output = & curl @args 2>&1
+        $lines = ($output -join "`n") -split "`n"
+        $code = 0
+        [void][int]::TryParse($lines[-1].Trim(), [ref]$code)
+        return @{ StatusCode = $code; Body = if ($lines.Count -gt 1) { ($lines[0..($lines.Count - 2)]) -join "`n" } else { '' } }
+    }
+
+    if ($RunNow) {
+        $response = Invoke-TaskApi -Method POST -Path "/api/v2/extendedAgent/scheduledTasks/$TaskName/run"
+        if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+            Write-Host "  ✅ Requested immediate run: $TaskName" -ForegroundColor Green
+            exit 0
+        }
+        Write-Host "  ℹ️  Run-now is not supported by the current API (HTTP $($response.StatusCode)). Use the portal or wait for the cron schedule." -ForegroundColor Yellow
+        exit 2
+    }
+
+    foreach ($auditTask in @('daily-rbac-cost-network-audit', 'hourly-automation-health')) {
+        $current = Invoke-TaskApi -Method GET -Path "/api/v2/extendedAgent/scheduledTasks/$auditTask"
+        if ($current.StatusCode -ne 200) { throw "Could not read $auditTask (HTTP $($current.StatusCode))." }
+        $task = $current.Body | ConvertFrom-Json
+        $task.properties.enabled = $Resume
+        $body = $task | ConvertTo-Json -Depth 20 -Compress
+        $updated = Invoke-TaskApi -Method PUT -Path "/api/v2/extendedAgent/scheduledTasks/$auditTask" -Body $body
+        if ($updated.StatusCode -lt 200 -or $updated.StatusCode -ge 300) { throw "Could not update $auditTask (HTTP $($updated.StatusCode))." }
+        Write-Host "  ✅ $auditTask enabled=$Resume" -ForegroundColor Green
+    }
+    exit 0
 }
 
 foreach ($resource in $profileResources) {

--- a/scripts/manage-azure-monitor-profile.ps1
+++ b/scripts/manage-azure-monitor-profile.ps1
@@ -5,6 +5,9 @@
 .PARAMETER ResourceGroupName
     Resource group containing the lab.
 
+.PARAMETER WorkloadName
+    Workload name used when the lab was deployed.
+
 .PARAMETER Cleanup
     Remove the profile's action group and scheduled-query alerts.
 
@@ -30,6 +33,10 @@ param(
     [string]$ResourceGroupName,
 
     [Parameter()]
+    [ValidateLength(3, 10)]
+    [string]$WorkloadName = 'srelab',
+
+    [Parameter()]
     [switch]$Cleanup,
 
     [Parameter()]
@@ -51,11 +58,11 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $profileResources = @(
-    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = 'alert-srelab-pod-restarts' },
-    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = 'alert-srelab-http-5xx' },
-    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = 'alert-srelab-pod-failures' },
-    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = 'alert-srelab-crashloop-oom' },
-    @{ Type = 'Microsoft.Insights/actionGroups'; Name = 'ag-srelab' }
+    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = "alert-$WorkloadName-pod-restarts" },
+    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = "alert-$WorkloadName-http-5xx" },
+    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = "alert-$WorkloadName-pod-failures" },
+    @{ Type = 'Microsoft.Insights/scheduledQueryRules'; Name = "alert-$WorkloadName-crashloop-oom" },
+    @{ Type = 'Microsoft.Insights/actionGroups'; Name = "ag-$WorkloadName" }
 )
 
 if ($Cleanup -and -not $ConfirmCleanup) {

--- a/scripts/verify-sre-agent-configuration.ps1
+++ b/scripts/verify-sre-agent-configuration.ps1
@@ -5,6 +5,9 @@
 .PARAMETER ResourceGroupName
     Name of the resource group containing the SRE Agent.
 
+.PARAMETER WorkloadName
+    Workload name used when the lab was deployed.
+
 .EXAMPLE
     .\verify-sre-agent-configuration.ps1 -ResourceGroupName "rg-srelab-eastus2"
 #>
@@ -13,6 +16,10 @@
 param(
     [Parameter(Mandatory)]
     [string]$ResourceGroupName,
+
+    [Parameter()]
+    [ValidateLength(3, 10)]
+    [string]$WorkloadName = 'srelab',
 
     [Parameter()]
     [switch]$RequireAzureMonitorAutomation,
@@ -72,10 +79,10 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) {
 if ($RequireAzureMonitorAutomation) {
     $monitorResources = @(az resource list --resource-group $ResourceGroupName --output json 2>$null | ConvertFrom-Json)
     $requiredAlertNames = @(
-        'alert-srelab-pod-restarts',
-        'alert-srelab-http-5xx',
-        'alert-srelab-pod-failures',
-        'alert-srelab-crashloop-oom'
+        "alert-$WorkloadName-pod-restarts",
+        "alert-$WorkloadName-http-5xx",
+        "alert-$WorkloadName-pod-failures",
+        "alert-$WorkloadName-crashloop-oom"
     )
     foreach ($alertName in $requiredAlertNames) {
         if (@($monitorResources | Where-Object { $_.type -eq 'Microsoft.Insights/scheduledQueryRules' -and $_.name -eq $alertName }).Count -eq 1) {
@@ -86,11 +93,12 @@ if ($RequireAzureMonitorAutomation) {
         }
     }
 
-    if (@($monitorResources | Where-Object { $_.type -eq 'Microsoft.Insights/actionGroups' -and $_.name -eq 'ag-srelab' }).Count -eq 1) {
-        Write-Host '  ✅ Azure Monitor action group/ag-srelab' -ForegroundColor Green
+    $actionGroupName = "ag-$WorkloadName"
+    if (@($monitorResources | Where-Object { $_.type -eq 'Microsoft.Insights/actionGroups' -and $_.name -eq $actionGroupName }).Count -eq 1) {
+        Write-Host "  ✅ Azure Monitor action group/$actionGroupName" -ForegroundColor Green
     }
     else {
-        Add-Failure -Component 'Azure Monitor action group/ag-srelab' -Reason 'Expected action group was not found'
+        Add-Failure -Component "Azure Monitor action group/$actionGroupName" -Reason 'Expected action group was not found'
     }
 }
 

--- a/scripts/verify-sre-agent-configuration.ps1
+++ b/scripts/verify-sre-agent-configuration.ps1
@@ -107,6 +107,21 @@ else {
     Write-Host '  ℹ️  Microsoft Learn MCP connector skipped (opt-in).' -ForegroundColor Gray
 }
 
+if ($RequireAzureMonitorAutomation) {
+    foreach ($taskName in @('daily-rbac-cost-network-audit', 'hourly-automation-health')) {
+        $taskResponse = Invoke-DataplaneApi -Url "$agentEndpoint/api/v2/extendedAgent/scheduledTasks/$taskName" -Token $token
+        if ($taskResponse.StatusCode -eq 200) {
+            Write-Host "  ✅ Azure Monitor automation task/$taskName" -ForegroundColor Green
+        }
+        else {
+            Add-Failure -Component "Azure Monitor automation task/$taskName" -Reason "HTTP $($taskResponse.StatusCode)"
+        }
+    }
+}
+else {
+    Write-Host '  ℹ️  Azure Monitor automation tasks skipped (opt-in).' -ForegroundColor Gray
+}
+
 $checks = @(
     @{ Name = 'Knowledge base'; Path = '/api/v1/AgentMemory/files'; Test = { param($data) @($data.files | Where-Object { $_.isIndexed }).Count -gt 0 } },
     @{ Name = 'Custom agents'; Path = '/api/v2/extendedAgent/agents'; Test = {


### PR DESCRIPTION
## Summary
- add an opt-in Azure Monitor automation profile with four scheduled-query alerts and an action group
- configure and verify the profile's scheduled SRE Agent health and audit tasks
- add pause, resume, run-now, inspection, and guarded cleanup controls
- honor custom workload names throughout deployment, management, and verification
- update the setup guidance for profile operations

## Validation
- Azure Resource Manager subscription deployment validation: succeeded with `deployAlerts=true` and `deployActionGroup=true`
- Bicep compilation: succeeded for `main.bicep`, `main.bicepparam`, and `modules/alerts.bicep`
- PowerShell parser: all 13 tracked scripts passed
- mocked profile management and end-to-end configuration verification: passed for a non-default workload name
- governance contract static validation: passed
- VS Code diagnostics and `git diff --check`: clean

## Notes
- Bicep reports two existing warnings in `modules/aks.bicep` (`BCP174` and `no-unnecessary-dependson`); neither is introduced by this branch.
- Live deployment was not performed; ARM validation was non-destructive.